### PR TITLE
Add Infinite secret storage and fix onetime secret deletion before de…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,44 @@ $ yopass-server -h
 
 Encrypted secrets can be stored either in Memcached or Redis by changing the `--database` flag.
 
+## Development
+
+To download go dependencies ( go should be installed)
+
+```
+go mod tidy
+```
+
+To run cli client
+
+```
+cd cmd/yopass
+go build
+./yopass --expiration="0" --one-time=false --api http://localhost:1337  --key "random" --url http://localhost:1337 <<< 'testing'
+```
+
+To run server
+
+```
+cd cmd/yopass-server
+go build
+./yopass-server --database "redis"
+```
+
+To run website 
+
+```
+cd website
+yarn install
+REACT_APP_BACKEND_URL='http://localhost:1337' yarn start
+```
+
+To run DB, using docker
+
+```
+docker run -p 6379:6379 redis
+```
+
 ### Docker Compose
 
 Use the Docker Compose file `deploy/with-nginx-and-letsencrypt/docker-compose.yml` to set up a yopass instance with TLS transport encryption and certificate auto renewal using [Let's Encrypt](https://letsencrypt.org/). First point your domain to the host you want to run yopass on. Then replace the placeholder values for `VIRTUAL_HOST`, `LETSENCRYPT_HOST` and `LETSENCRYPT_EMAIL` in `deploy/with-nginx-and-letsencrypt/docker-compose.yml` with your values. Afterwards change the directory to `deploy/with-nginx-and-letsencrypt` and start the containers with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We take the security of Yopass seriously. If you believe you have discovered a s
 
 Please follow these guidelines when reporting a security issue:
 
-1. Email the report to z0x0z.bb{a}gmail.com. Please do not create a public GitHub issue.
+1. Email the report to johan{a}haals.se. Please do not create a public GitHub issue.
 2. Provide a detailed description of the vulnerability, including steps to reproduce the issue, potential impact, and any suggested mitigations or remediations.
 3. Allow a reasonable time for the Yopass maintainers to respond to your report and address the vulnerability before publicly disclosing it. We will keep you updated on our progress.
 

--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -106,7 +106,7 @@ func decrypt(out io.Writer) error {
 		key = viper.GetString("key")
 	}
 
-	msg, err := yopass.Fetch(viper.GetString("api"), id)
+	msg, onetime, err := yopass.Fetch(viper.GetString("api"), id)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch secret: %w", err)
 	}
@@ -114,6 +114,13 @@ func decrypt(out io.Writer) error {
 	pt, _, err := yopass.Decrypt(strings.NewReader(msg), key)
 	if err != nil {
 		return fmt.Errorf("Failed to decrypt secret: %w", err)
+	}
+
+	if onetime {
+		_, err := yopass.Delete(viper.GetString("api"), id)
+		if err != nil {
+			return fmt.Errorf("unable to delete secret: %w", err)
+		}
 	}
 
 	// Note yopass decrypt currently always prints the content to stdout. This

--- a/pkg/server/redis.go
+++ b/pkg/server/redis.go
@@ -35,12 +35,6 @@ func (r *Redis) Get(key string) (yopass.Secret, error) {
 		return s, err
 	}
 
-	if s.OneTime {
-		if err := r.client.Del(key).Err(); err != nil {
-			return s, err
-		}
-	}
-
 	return s, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -82,7 +82,8 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	resp := map[string]string{"message": key}
+	// Response - contain both message (string) & onetime (bool) expiration detail
+	resp := map[string]interface{}{"message": key, "one_time": s.OneTime}
 	jsonData, err := json.Marshal(resp)
 	if err != nil {
 		y.logger.Error("Failed to marshal create secret response", zap.Error(err), zap.String("key", key))
@@ -121,7 +122,6 @@ func (y *Server) getSecret(w http.ResponseWriter, request *http.Request) {
 // deleteSecret from database
 func (y *Server) deleteSecret(w http.ResponseWriter, request *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-
 	deleted, err := y.db.Delete(mux.Vars(request)["key"])
 	if err != nil {
 		http.Error(w, `{"message": "Failed to delete secret"}`, http.StatusInternalServerError)
@@ -132,7 +132,6 @@ func (y *Server) deleteSecret(w http.ResponseWriter, request *http.Request) {
 		http.Error(w, `{"message": "Secret not found"}`, http.StatusNotFound)
 		return
 	}
-
 	w.WriteHeader(204)
 }
 

--- a/pkg/yopass/client.go
+++ b/pkg/yopass/client.go
@@ -27,17 +27,36 @@ func (e *ServerError) Unwrap() error {
 
 type serverResponse struct {
 	Message string `json:"message"`
+	OneTime bool   `json:"one_time"`
 }
 
 // Fetch retrieves a secret by its ID from the specified server.
-func Fetch(server string, id string) (string, error) {
+func Fetch(server string, id string) (string, bool, error) {
 	server = strings.TrimSuffix(server, "/")
 
 	resp, err := HTTPClient.Get(server + "/secret/" + id)
 	if err != nil {
+		return "", false, &ServerError{err: err}
+	}
+
+	return handleServerResponse(resp)
+}
+
+func Delete(server string, id string) (string, error) {
+	server = strings.TrimSuffix(server, "/")
+
+	req, err := http.NewRequest("DELETE", server+"/secret/"+id, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
 		return "", &ServerError{err: err}
 	}
-	return handleServerResponse(resp)
+
+	msg, _, err := handleServerResponse(resp)
+	return msg, err
 }
 
 // Store sends the secret to the specified server and returns the secret ID.
@@ -52,25 +71,36 @@ func Store(server string, s Secret) (string, error) {
 	if err != nil {
 		return "", &ServerError{err: err}
 	}
-	return handleServerResponse(resp)
+
+	msg, _, err := handleServerResponse(resp)
+	return msg, err
 }
 
-func handleServerResponse(resp *http.Response) (string, error) {
+func handleServerResponse(resp *http.Response) (string, bool, error) {
 	defer resp.Body.Close()
 
 	var r serverResponse
+
+	// Delete Operation
+	if (resp.Request.Method == http.MethodDelete) && (resp.StatusCode == http.StatusNoContent) { // During DELETE Call, status code will be 204 (successful deletion)
+		// As response body will be empty after delete, upon successful deletion response will be empty
+		return "", false, nil
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := ioutil.ReadAll(resp.Body)
 		if err := json.Unmarshal(msg, &r); err == nil {
 			msg = []byte(r.Message)
 		}
-		err := fmt.Errorf("unexpected response %s: %s", resp.Status, string(msg))
-		return "", &ServerError{err: err}
+		err := fmt.Errorf("%s: unexpected response %s: %s", resp.Request.Method, resp.Status, string(msg))
+		return "", false, &ServerError{err: err}
 	}
+
 
 	if err := (json.NewDecoder(resp.Body)).Decode(&r); err != nil {
-		return "", fmt.Errorf("could not decode server response: %w", err)
+		return "", false, fmt.Errorf("could not decode server response: %w", err)
 	}
 
-	return r.Message, nil
+
+	return r.Message, r.OneTime, nil
 }

--- a/pkg/yopass/client_test.go
+++ b/pkg/yopass/client_test.go
@@ -24,7 +24,7 @@ func TestFetch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := yopass.Fetch(ts.URL, key)
+	got, _, err := yopass.Fetch(ts.URL, key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,14 +32,14 @@ func TestFetch(t *testing.T) {
 		t.Errorf("expected fetched message to be %q, got %q", msg, got)
 	}
 
-	_, err = yopass.Fetch(ts.URL, "4b9502b0-112a-40f5-a872-000000000000")
+	_, _, err = yopass.Fetch(ts.URL, "4b9502b0-112a-40f5-a872-000000000000")
 	if want := new(yopass.ServerError); !errors.As(err, &want) {
 		t.Errorf("expected a ServerError, got %v", err)
 	}
 }
 
 func TestFetchInvalidServer(t *testing.T) {
-	_, err := yopass.Fetch("127.0.0.1:9999/invalid", "1337")
+	_,_, err := yopass.Fetch("127.0.0.1:9999/invalid", "1337")
 	if err == nil {
 		t.Error("expected error, got none")
 	}

--- a/website/src/displaySecret/DisplaySecret.tsx
+++ b/website/src/displaySecret/DisplaySecret.tsx
@@ -73,6 +73,12 @@ const EnterDecryptionKey = ({
   );
 };
 
+const deleteSecret = async (url: string): Promise<Response> => {
+  return await fetch(url, {
+    method: 'DELETE',
+  });
+};
+
 const DisplaySecret = () => {
   const { t } = useTranslation();
   const { format, key, password: paramsPassword } = useParams();
@@ -96,7 +102,7 @@ const DisplaySecret = () => {
     setLoadSecret(!!password);
   }, [password, key]);
 
-  // Load the secret data when required
+  // Load the secret data when required - loads data from the browser cache
   const { data, error } = useSWR(loadSecret ? url : null, fetcher, {
     shouldRetryOnError: false,
     revalidateOnFocus: false,
@@ -143,6 +149,13 @@ const DisplaySecret = () => {
     );
   }
   if (value) {
+    // Call delete after decryption for onetime
+    if(data.one_time) {
+      const deleteKey = async () => {
+        await deleteSecret(url);
+      }     
+      deleteKey();
+    }
     return (
       <>
         <Secret secret={value.data as string} fileName={value.filename} />


### PR DESCRIPTION
- Add Infinite secret storage (expiration="0")
- Prevent one-time enabled secrets from getting deleted on get calls (without validating the entered key) - Only applicable for REDIS
- Delete secrets after decryption is successful for one-time enabled secrets - Only applicable for REDIS
- Updated README with Developer Instructions for testing the application locally